### PR TITLE
Feature/support insecure default cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,6 @@ This library also provides additional functionality for that encrypts the payloa
 3. A `schedule_once` method, which can be used when calling the task method (ex: `my_job.schedule_once()`). This method has the same functionality as `django_rq.Scheduler.schedule`, but will check if the method already exists and will not add it to the scheduler a second time.
 
 ## Important:
-When using the `@secure_redis.secure_rq.job decorator`, the method name displayed in the Django admin will be that of the wrapped proxy method instead of the actual task method name. If you want to see the actual task method name in the Django admin, you must use `secure_redis.urls` instead of `django_rq.urls` when installing RQ into the Django admin in your `urls.py` file.
+* When using the `@secure_redis.secure_rq.job decorator`, the method name displayed in the Django admin will be that of the wrapped proxy method instead of the actual task method name. If you want to see the actual task method name in the Django admin, you must use `secure_redis.urls` instead of `django_rq.urls` when installing RQ into the Django admin in your `urls.py` file.
+
+* If not planning to use django-rq functionality, setting `DJANGO_REDIS_SECURE_CACHE_NAME = None` will stop django-secure-redis from initialising the cache for django-rq. By default django-secure-redis will look for the "default" cache name and if "default" has not been configured as a secure cache it will error.

--- a/secure_redis/settings.py
+++ b/secure_redis/settings.py
@@ -9,7 +9,7 @@ def get_secure_cache_name():
     Return the cache name to use for django-rq functionality
     """
     if not hasattr(settings, 'DJANGO_REDIS_SECURE_CACHE_NAME'):
-        cache_name = "default"
+        cache_name = 'default'
     else:
         cache_name = settings.DJANGO_REDIS_SECURE_CACHE_NAME
     return cache_name
@@ -25,12 +25,12 @@ def get_secure_cache_opts():
     # If `DJANGO_REDIS_SECURE_CACHE_NAME` is explicitly set to `None`, don't
     # return the options dict, django-rq functionality has been turned off
     if cache_name is not None:
-        secure_cache_opts = settings.CACHES[cache_name].get('OPTIONS', None)
+        secure_cache_opts = settings.CACHES[cache_name].get('OPTIONS')
         if not secure_cache_opts:
             raise ImproperlyConfigured(
                 'OPTIONS must be defined in settings in secure cache settings!')
 
-        if secure_cache_opts.get("SERIALIZER") == 'secure_redis.serializer.SecureSerializer':
+        if secure_cache_opts['SERIALIZER'] == 'secure_redis.serializer.SecureSerializer':
             return secure_cache_opts
 
 

--- a/settings_test.py
+++ b/settings_test.py
@@ -1,9 +1,9 @@
 from __future__ import unicode_literals
 import os
-
+import platform
 
 BASE_DIR = os.path.dirname(__file__)
-APPSERVER = os.uname()[1]
+APPSERVER = platform.uname()[1]
 
 SITE_ID = 1
 INTERNAL_IPS = ('127.0.0.1', )


### PR DESCRIPTION
Attempting to resolve #8 while preserving the default behaviour. Added the ability to skip the `settings.py` initialisation by explicitly setting `DJANGO_REDIS_SECURE_CACHE_NAME = None`.  

Offering a concrete way for users to enable/disable the django-rq functionality would be easy enough but would obviously change the default behaviour and as this is a rare use-case I'm not sure how much accommodation it should be given.