### PR TITLE
Added explicit relative import + version bump

### DIFF
--- a/secure_redis/__init__.py
+++ b/secure_redis/__init__.py
@@ -1,4 +1,4 @@
-import settings
+from . import settings
 
 
-__version__ = '1.1.2'
+__version__ = '1.1.3'


### PR DESCRIPTION
the relative import was causing the package to fail to load on py3, changed to an explicit relative import to match elsewhere in the code