### PR TITLE
Replacing a implicit settings import

### DIFF
--- a/secure_redis/__init__.py
+++ b/secure_redis/__init__.py
@@ -1,4 +1,4 @@
 from . import settings
 
 
-__version__ = '1.1.3'
+__version__ = '1.1.4'

--- a/secure_redis/serializer.py
+++ b/secure_redis/serializer.py
@@ -4,7 +4,7 @@ from cryptography.fernet import Fernet
 
 import django_redis.serializers.pickle
 
-import settings
+from . import settings
 
 
 class SecureSerializer(django_redis.serializers.pickle.PickleSerializer):
@@ -21,5 +21,6 @@ class SecureSerializer(django_redis.serializers.pickle.PickleSerializer):
     def loads(self, value):
         val = self.crypter.decrypt(value)
         return super(SecureSerializer, self).loads(val)
+
 
 default_secure_serializer = SecureSerializer(settings.get_secure_cache_opts())


### PR DESCRIPTION
I must have missed this when I made the previous PR-  there's another implicit `import settings` in a different module that throws an error in py3